### PR TITLE
Fix some python3 errors

### DIFF
--- a/install.py
+++ b/install.py
@@ -48,13 +48,13 @@ def install (file, dir, mode):
 	f = getDest (file, dir)
 	print ("install: " + f)
 	run ('install -d ' + dest + prefix + dir)
-	run ('install -m ' + str(mode) + ' '   + file + ' ' + dest + prefix + dir + '/')
+	run ('install -m ' + str(mode) + ' ' + file + ' ' + dest + prefix + dir + '/')
 
 def install_root (file, dir, mode):
 	f = getDestRoot (file, dir)
 	print ("install: " + f)
 	run ('install -d ' + dest + dir)
-	run ('install -m ' + str(mode) + ' '   + file + ' ' + dest + dir + '/')
+	run ('install -m ' + str(mode) + ' ' + file + ' ' + dest + dir + '/')
 
 def link (dir, file, linkname):
 	f = getDest (linkname, dir)

--- a/install.py
+++ b/install.py
@@ -43,7 +43,7 @@ def getDestRoot (file, dir):
 	else:
 		f += file
 	return f
-	
+
 def install (file, dir, mode):
 	f = getDest (file, dir)
 	print ("install: " + f)

--- a/install.py
+++ b/install.py
@@ -48,19 +48,19 @@ def install (file, dir, mode):
 	f = getDest (file, dir)
 	print ("install: " + f)
 	run ('install -d ' + dest + prefix + dir)
-	run ('install -m ' + `mode` + ' '   + file + ' ' + dest + prefix + dir + '/')
+	run ('install -m ' + str(mode) + ' '   + file + ' ' + dest + prefix + dir + '/')
 
 def install_root (file, dir, mode):
-   f = getDestRoot (file, dir)
-   print ("install: " + f)
-   run ('install -d ' + dest + dir)
-   run ('install -m ' + `mode` + ' '   + file + ' ' + dest + dir + '/')
+	f = getDestRoot (file, dir)
+	print ("install: " + f)
+	run ('install -d ' + dest + dir)
+	run ('install -m ' + str(mode) + ' '   + file + ' ' + dest + dir + '/')
 
 def link (dir, file, linkname):
 	f = getDest (linkname, dir)
 	print ("install link: " + f)
 	run ('cd ' + dest + prefix + dir + ' && ln -sf ' + file + ' ' + linkname)
-	
+
 parser = OptionParser()
 parser.add_option ("-l", "--libdir", dest="libdir", help="path to directory for shared libraries (lib or lib64).")
 parser.add_option ("-d", "--dest", dest="dest", help="install to this directory", metavar="DEST")
@@ -90,24 +90,23 @@ else:
 	libdir = options.libdir
 
 if "openbsd" in sys.platform:
-    install ('build/bin/libxmlbird.so.' + '${LIBxmlbird_VERSION}', '/lib', 644)
+	install ('build/bin/libxmlbird.so.' + '${LIBxmlbird_VERSION}', '/lib', 644)
 elif os.path.isfile ('build/bin/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION):
-   install ('build/bin/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, libdir, 644)
-   link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
-   link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so')
+	install ('build/bin/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, libdir, 644)
+	link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
+	link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so')
 elif os.path.isfile ('build/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION):
-   install ('build/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, libdir, 644)
-   link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
-   link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so')
+	install ('build/libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, libdir, 644)
+	link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
+	link (libdir, 'libxmlbird.so.' + version.LIBXMLBIRD_SO_VERSION, ' libxmlbird.so')
 elif os.path.isfile ('build/bin/libxmlbird.' + version.LIBXMLBIRD_SO_VERSION + '.dylib'):
-   install ('build/bin/libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', libdir, 644)
-   link (libdir, 'libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', ' libxmlbird.dylib.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
-   link (libdir, 'libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', ' libxmlbird.dylib')
+	install ('build/bin/libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', libdir, 644)
+	link (libdir, 'libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', ' libxmlbird.dylib.' + version.LIBXMLBIRD_SO_VERSION_MAJOR)
+	link (libdir, 'libxmlbird-' + version.LIBXMLBIRD_SO_VERSION + '.dylib', ' libxmlbird.dylib')
 else:
-   print ("Can't find libxmlbird.")
-   exit (1)
+	print ("Can't find libxmlbird.")
+	exit (1)
 
 install ('build/xmlbird/xmlbird.h', '/include', 644)
 install ('build/xmlbird.vapi', '/share/vala/vapi', 644)
 install ('build/xmlbird.pc', libdir + '/pkgconfig', 644)
-


### PR DESCRIPTION
This should fix several tab/space and converting errors I had when building with python3 on Arch x86_64.
