### PR TITLE
configure/test: respect --valac option

### DIFF
--- a/configure
+++ b/configure
@@ -44,8 +44,8 @@ def test_library_version (lib):
 	process.communicate()[0]
 	return process.returncode == 0
 
-def configure ():	
-	if not test_program_version ("valac", 0, 16, 0):
+def configure(valac):
+	if not test_program_version(valac, 0, 16, 0):
 		print (FAIL + "valac is too old." + ENDC)
 		exit (1)
 
@@ -105,7 +105,7 @@ if not options.nonnull:
 else:
 	options.nonnull = True
 	
-configure()
+configure(options.valac)
 
 configfile.write_compile_parameters(options.prefix,
 									options.dest,

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 import subprocess
-from scripts.config import PREFIX
+from scripts.config import (PREFIX, VALAC)
 from scripts.run import run
 from scripts.version import LIBXMLBIRD_SO_VERSION
 
@@ -32,7 +32,7 @@ def build_tests():
     run ("mkdir -p build/tests");
 
     for test in tests:
-        run ("valac --ccode --pkg=posix --pkg=xmlbird --vapidir=./build "
+        run (VALAC + " --ccode --pkg=posix --pkg=xmlbird --vapidir=./build "
              + "--directory=./build tests/" + test + ".vala tests/Test.vala");
 
         run ("""gcc -fPIC -c \


### PR DESCRIPTION
Make sure we don't still test `valac` when the compiler has been set to
a specific version/path.
